### PR TITLE
fix: configuration

### DIFF
--- a/config/bundles.php
+++ b/config/bundles.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    M10c\NativePushNotifierBundle\M10cNativePushNotifierBundle::class => ['all' => true],
+];

--- a/config/notifier.yaml
+++ b/config/notifier.yaml
@@ -1,0 +1,5 @@
+framework:
+  notifier:
+    texter_transports:
+      apns: '%env(NOTIFIER_APNS_DSN)%'
+      fcm: '%env(NOTIFIER_FCM_DSN)%'


### PR DESCRIPTION
These changes are the difference b/w B and D after installing m10c/native-push-notifier-bundle.
And then I had to upgrade symfony/notifier to version "^7.0" from "^5.4".

For some reason in D symfony/notifier version 5.4 is getting installed, but 7.0 in B.