### PR TITLE
build: upgrade libs to support Symfony 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .*.cache
 composer.lock
 vendor/*
+.idea

--- a/composer.json
+++ b/composer.json
@@ -4,21 +4,22 @@
     "type": "symfony-bundle",
     "license": "MIT",
     "require": {
+        "php": ">=8.1",
         "google/auth": "^1.0",
         "lcobucci/jwt": "^5.0",
         "symfony/cache-contracts": "^3.0",
-        "symfony/clock": "^5.4 | ^6.0 | ^7.0",
-        "symfony/config": "^5.4 | ^6.0 | ^7.0",
-        "symfony/dependency-injection": "^5.4 | ^6.0 | ^7.0",
+        "symfony/clock": "^6.2 | ^7.0 | ^8.0",
+        "symfony/config": "^5.4 | ^6.0 | ^7.0 | ^8.0",
+        "symfony/dependency-injection": "^5.4 | ^6.0 | ^7.0 | ^8.0",
         "symfony/event-dispatcher-contracts": "^3.0",
         "symfony/http-client-contracts": "^3.0",
-        "symfony/http-kernel": "^5.4 | ^6.0 | ^7.0",
-        "symfony/notifier": "^5.4 | ^6.0 | ^7.0"
+        "symfony/http-kernel": "^5.4 | ^6.0 | ^7.0 | ^8.0",
+        "symfony/notifier": "^5.4 | ^6.0 | ^7.0 | ^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.57",
-        "phpstan/phpstan": "^1.11",
-        "symfony/phpunit-bridge": "^7.0"
+        "phpstan/phpstan": "^1.11 | ^2.0",
+        "symfony/phpunit-bridge": "^7.0 | ^8.0"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.57",
-        "phpstan/phpstan": "^1.11 | ^2.0",
-        "symfony/phpunit-bridge": "^7.0 | ^8.0"
+        "phpstan/phpstan": "^2.0",
+        "symfony/phpunit-bridge": "^8.0"
     },
     "config": {
         "sort-packages": true

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,7 @@
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
-        <server name="SYMFONY_PHPUNIT_VERSION" value="9.5" />
+        <server name="SYMFONY_PHPUNIT_VERSION" value="9.6" />
     </php>
 
     <testsuites>
@@ -21,11 +21,11 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />

--- a/src/ApnsTransport.php
+++ b/src/ApnsTransport.php
@@ -111,10 +111,11 @@ final class ApnsTransport extends AbstractTransport implements TexterInterface
         }
 
         if ($statusCode > 299) {
+            /** @var array{reason?: string, timestamp?: int} $res */
             $res = $response->toArray(throw: false);
             if ('Unregistered' === ($res['reason'] ?? null)) {
-                $unregisteredAt = $res['timestamp']
-                    ? \DateTimeImmutable::createFromFormat('U', sprintf('%d', floor($res['timestamp'] / 1000)))
+                $unregisteredAt = isset($res['timestamp'])
+                    ? \DateTimeImmutable::createFromFormat('U', (string) intdiv($res['timestamp'], 1000))
                     : null;
                 throw new TokenUnregisteredException(token: $token, transport: 'apns', unregisteredAt: $unregisteredAt ?: null);
             }

--- a/src/FcmTransport.php
+++ b/src/FcmTransport.php
@@ -106,9 +106,10 @@ final class FcmTransport extends AbstractTransport implements TexterInterface
             throw new TransportException('Could not reach the remote FCM server.', $response, 0, $e);
         }
 
+        /** @var array{error?: array{details?: list<array{errorCode?: string}>}} $res */
         $res = $response->toArray(throw: false);
 
-        if (404 === $statusCode && 'UNREGISTERED' === $res['error']['details'][0]['errorCode']) {
+        if (404 === $statusCode && 'UNREGISTERED' === ($res['error']['details'][0]['errorCode'] ?? null)) {
             throw new TokenUnregisteredException(token: $token, transport: 'fcm');
         }
 
@@ -116,8 +117,10 @@ final class FcmTransport extends AbstractTransport implements TexterInterface
             throw new TransportException("Unable to send the Push to token: {$token}, FCM responded with {$statusCode}.", $response);
         }
 
+        /** @var array{name?: string} $responseArr */
         $responseArr = $response->toArray();
-        if (!isset($responseArr['name']) || !str_contains($responseArr['name'], '/messages/')) {
+
+        if (!str_contains($responseArr['name'] ?? '', '/messages/')) {
             throw new TransportException('Unexpected FCM response when sending the push', $response);
         }
 


### PR DESCRIPTION
Currently, if we try to update projects using this package, the update will be blocked as this package restricts the Symfony version to `7.*`. This PR upgrades the package and adds support for the latest Symfony version.